### PR TITLE
Fixed copy, permissions and ownerships of the configuration files.

### DIFF
--- a/roles/kubernetes/tasks/master.yml
+++ b/roles/kubernetes/tasks/master.yml
@@ -66,6 +66,7 @@
         owner: root
         group: root
         mode: 0755
+  become: true
   when:
     - k8s_multi_master | bool
 
@@ -195,6 +196,7 @@
         --discovery-token-ca-cert-hash sha256:{{ hostvars[k8s_master_node]['k8s_discovery_token_ca_cert_hash'] }} \
         --control-plane \
         --certificate-key {{ k8s_master_cert_key }}
+      become: true
 
     - name: Copying required files
       copy:

--- a/roles/kubernetes/tasks/master.yml
+++ b/roles/kubernetes/tasks/master.yml
@@ -97,7 +97,7 @@
     - name: Copying required files
       copy:
         src: '/etc/kubernetes/admin.conf'
-        dest:  '.kube/config'
+        dest:  '~{{ ansible_user }}/.kube/config'
         remote_src: yes
         owner: "{{ ansible_user }}"
       become: true
@@ -106,7 +106,6 @@
       template:
         src: "templates/{{ k8s_network_addon }}.yaml.j2"
         dest:  "kubernetes/{{ k8s_network_addon }}.yaml"
-        owner: "{{ ansible_user }}"
 
     - name: Install Network Add-on
       command: "kubectl apply -f kubernetes/{{ k8s_network_addon }}.yaml"
@@ -116,7 +115,6 @@
           copy:
             src: "files/{{ item }}"
             dest:  "kubernetes/{{ item }}"
-            owner: "{{ ansible_user }}"
           with_items:
             - "{{ k8s_dashboard_resources }}"
 

--- a/roles/kubernetes/tasks/master.yml
+++ b/roles/kubernetes/tasks/master.yml
@@ -195,6 +195,8 @@
         --control-plane \
         --certificate-key {{ k8s_master_cert_key }}
       become: true
+      when:
+        - k8s_node_join_status.stdout != "Ready"
 
     - name: Copying required files
       copy:
@@ -202,8 +204,6 @@
         dest:  '~{{ ansible_user }}/.kube/config'
         remote_src: yes
         owner: "{{ ansible_user }}"
-      when:
-        - k8s_node_join_status.stdout != "Ready"
       become: true
   when:
     - inventory_hostname != k8s_master_node

--- a/roles/kubernetes/tasks/master.yml
+++ b/roles/kubernetes/tasks/master.yml
@@ -68,7 +68,14 @@
         mode: 0755
   when:
     - k8s_multi_master | bool
-    - inventory_hostname == k8s_master_node
+
+- name: Create local directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - .kube
+    - kubernetes
 
 - name: Setting up the master node
   block:
@@ -85,15 +92,6 @@
         --certificate-key {{ k8s_master_cert_key }} \
         --upload-certs
       become: true
-
-    - name: Create local directories
-      file:
-        path: "{{ item }}"
-        state: directory
-        owner: "{{ ansible_user }}"
-      with_items:
-        - .kube
-        - kubernetes
 
     - name: Copying required files
       copy:
@@ -197,6 +195,13 @@
         --discovery-token-ca-cert-hash sha256:{{ hostvars[k8s_master_node]['k8s_discovery_token_ca_cert_hash'] }} \
         --control-plane \
         --certificate-key {{ k8s_master_cert_key }}
+
+    - name: Copying required files
+      copy:
+        src: '/etc/kubernetes/admin.conf'
+        dest:  '~{{ ansible_user }}/.kube/config'
+        remote_src: yes
+        owner: "{{ ansible_user }}"
       when:
         - k8s_node_join_status.stdout != "Ready"
       become: true


### PR DESCRIPTION
* haproxy/keepalived static pods are also installed for other masters
  to enable HA behavior.
* The configuration files are copied on all masters. Now if 1 master
  node fails the kubectl interface can still be accessible on other
  master nodes.
* We added "become: true" for the files placed in privileged paths and
  owned by root.
* Control-plane join command must be run as root
* "owner:" is not necessary if the user has write permissions for the
  destination path and read permission for the source file.
* "owner:" throw an exception if the user is not root
* We specified explicitly the ansible_user home to copy the file
  '/etc/Kubernetes/admin.conf' in the right path. This is necessary
  because only the root user has access to the file. With this change,
  even though the root user copies the file, the home path is still the
  ansible_user home.