### PR TITLE
Fix/ceph csi

### DIFF
--- a/roles/kubernetes/tasks/ceph-csi.yml
+++ b/roles/kubernetes/tasks/ceph-csi.yml
@@ -5,7 +5,6 @@
   template:
     src: "templates/ceph-csi-secret.yaml.j2"
     dest:  "kubernetes/ceph-csi-secret.yaml"
-    owner: "{{ lookup('env', 'USER') }}"
 
 - name: Check whether the secret is already defined
   command: kubectl get secret csi-rbd-secret -o jsonpath='{.metadata.name}'
@@ -24,7 +23,6 @@
   template:
     src: "templates/ceph-csi-config.yaml.j2"
     dest:  "kubernetes/ceph-csi-config.yaml"
-    owner: "{{ lookup('env', 'USER') }}"
 
 - name: Check whether the config map is already defined
   command: kubectl get configmap ceph-csi-config -o jsonpath='{.metadata.name}'
@@ -42,7 +40,6 @@
   template:
     src: "templates/ceph-csi-encryption-kms-config.yaml.j2"
     dest:  "kubernetes/ceph-csi-encryption-kms-config.yaml"
-    owner: "{{ lookup('env', 'USER') }}"
 
 - name: Check whether the Ceph CSI encryption KMS config map is already defined
   command: kubectl get configmap ceph-csi-encryption-kms-config -o jsonpath='{.metadata.name}'
@@ -111,7 +108,6 @@
   template:
     src: "templates/ceph-csi-storageclass.yaml.j2"
     dest:  "kubernetes/ceph-csi-storageclass.yaml"
-    owner: "{{ lookup('env', 'USER') }}"
 
 - name: Check whether the StorageClass is already defined
   command: kubectl get storageclass csi-rbd-sc -o jsonpath='{.metadata.name}'

--- a/roles/kubernetes/tasks/master.yml
+++ b/roles/kubernetes/tasks/master.yml
@@ -97,9 +97,9 @@
     - name: Copying required files
       copy:
         src: '/etc/kubernetes/admin.conf'
-        dest:  "~{{ lookup('env', 'USER') }}/.kube/config"
+        dest:  "~{{ ansible_user_id }}/.kube/config"
         remote_src: yes
-        owner: "{{ lookup('env', 'USER') }}"
+        owner: "{{ ansible_user_id }}"
       become: true
 
     - name: Deploying network addon template
@@ -154,6 +154,7 @@
     - name: Get Token from Kubernetes
       shell: |
         set -o pipefail
+        if [ !$(kubeadm token list) ]; then kubeadm token create ; fi
         kubeadm token list | grep 'system:bootstrappers:kubeadm' | awk '{print $1}'
       register: k8s_token_output
       changed_when: false
@@ -201,9 +202,9 @@
     - name: Copying required files
       copy:
         src: '/etc/kubernetes/admin.conf'
-        dest:  "~{{ lookup('env', 'USER') }}/.kube/config"
+        dest:  "~{{ ansible_user_id }}/.kube/config"
         remote_src: yes
-        owner: "{{ lookup('env', 'USER') }}"
+        owner: "{{ ansible_user_id }}"
       become: true
   when:
     - inventory_hostname != k8s_master_node


### PR DESCRIPTION
* If the tokens generated by k8s are expired, the script generates new
  ones
* `{{ lookup('env', 'USER') }}` import local USER environment variable
  if is not null. We changed this to `ansible_user_id`, to ensure that
  the value is the same user of the ssh session user.
* "owner:" is not necessary if the user has write permissions for the
  destination path and read permission for the source file.
* If the user is not root "owner:" causes playbook failure